### PR TITLE
Passes e to custom onChange function

### DIFF
--- a/ToggleSwitch.js
+++ b/ToggleSwitch.js
@@ -15,7 +15,7 @@ class ToggleSwitch extends Component {
     this.setState({
       checked: e.target.checked
     });
-    if (typeof this.props.onChange === "function") this.props.onChange();
+    if (typeof this.props.onChange === "function") this.props.onChange(e);
   };
   render() {
     return (


### PR DESCRIPTION
I wanted to thank you for your excellent tutorial!

I had just one issue: the example code `onChange={function (e) { console.log("Checkbox Current State: " + e.target.checked); }}` actually doesn't work, because `e` is never passed to this function inside the code. 

This pull request resolves that issue.